### PR TITLE
Recalculate Fix message checksum when modifying header

### DIFF
--- a/etiqet-fix/src/main/java/com/neueda/etiqet/fix/client/delegate/ReplaceParamFixClientDelegate.java
+++ b/etiqet-fix/src/main/java/com/neueda/etiqet/fix/client/delegate/ReplaceParamFixClientDelegate.java
@@ -1,11 +1,11 @@
 package com.neueda.etiqet.fix.client.delegate;
 
 import com.neueda.etiqet.core.client.delegate.ClientDelegate;
-import com.neueda.etiqet.core.common.cdr.CdrItem;
 import com.neueda.etiqet.core.common.exceptions.StopEncodingException;
-import com.neueda.etiqet.core.config.GlobalConfig;
-import com.neueda.etiqet.fix.config.FixConfigConstants;
+import com.neueda.etiqet.fix.message.FIXMsg;
+import quickfix.DefaultMessageFactory;
 import quickfix.Message;
+import quickfix.MessageUtils;
 
 /**
  * Delegate for QuickFix client that fills some necessary parameters when sending messages to the server.
@@ -30,25 +30,18 @@ public class ReplaceParamFixClientDelegate extends MessageFixClientDelegate {
 
     @Override
     public String transformAfterEncoding(String msg) throws StopEncodingException {
-        String transformed = msg;
 
         // If message with params has been defined then replace with message's values.
         if(message != null) {
             try {
-                StringBuilder buffer = new StringBuilder();
-                for(String entry: msg.split(FIELD_SEPARATOR)) {
-                    String[] keyValuePair = entry.split("=");
-                    String tagName = GlobalConfig.getInstance().getProtocol(FixConfigConstants.PROTOCOL_NAME)
-                                                               .getNameForTag(Integer.parseInt(keyValuePair[0]));
-                    CdrItem toReplaceWith = message.getItem(tagName);
-                    String value = (toReplaceWith != null)? toReplaceWith.toString(): keyValuePair[1];
-                    buffer.append(keyValuePair[0]).append(KEY_VALUE_SEPARATOR).append(value).append(FIELD_SEPARATOR);
-                }
-                transformed = buffer.toString();
+                Message fixMessage = MessageUtils.parse(new DefaultMessageFactory(), null, msg);
+                FIXMsg fixMsg = new FIXMsg(fixMessage);
+                fixMessage = fixMsg.updateWithCdr(message);
+                msg = fixMessage.toString();
             } catch (Exception e) {
                 throw new StopEncodingException(e);
             }
         }
-        return super.transformAfterEncoding(transformed);
+        return super.transformAfterEncoding(msg);
     }
 }

--- a/etiqet-fix/src/main/java/com/neueda/etiqet/fix/message/FIXMsg.java
+++ b/etiqet-fix/src/main/java/com/neueda/etiqet/fix/message/FIXMsg.java
@@ -25,6 +25,10 @@ public class FIXMsg {
 	public FIXMsg() {
 	}
 
+	public FIXMsg(FieldMap instance){
+		this.instance = instance;
+	}
+
 	public FIXMsg(Cdr d, FieldMap instance) {
 		this.instance = instance;
 		try {
@@ -45,6 +49,11 @@ public class FIXMsg {
 		if (messageConfig != null) {
 			ParserUtils.fillDefault(messageConfig, data);
 		}
+	}
+
+	public Message updateWithCdr(Cdr data) throws EtiqetException{
+		encode(data);
+		return (Message) instance;
 	}
 
 	public Message serialize(Cdr cdr) throws EtiqetException {


### PR DESCRIPTION
- Old transformAfterEncoding modified fix message as a string and did not recalculate the checksum
- New code parses the string as a quickfix.Message before making modifications, checksum and msglength are calculated when toString is called
- Updated FIXMsg to enable updating an existing Message with some cdr values