### PR TITLE
Added StopEvent to client

### DIFF
--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/client/Client.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/client/Client.java
@@ -2,6 +2,8 @@ package com.neueda.etiqet.core.client;
 
 import com.neueda.etiqet.core.client.delegate.ClientDelegate;
 import com.neueda.etiqet.core.client.delegate.SinkClientDelegate;
+import com.neueda.etiqet.core.client.event.StopEvent;
+import com.neueda.etiqet.core.client.event.StopObserver;
 import com.neueda.etiqet.core.common.Environment;
 import com.neueda.etiqet.core.common.EtiqetEvent;
 import com.neueda.etiqet.core.common.cdr.Cdr;
@@ -38,6 +40,7 @@ public abstract class Client<U, M> implements Codec<U>, Runnable {
 
     private static final int DEFAULT_TIMEOUT_MILLIS = 5000;
     private static final int LOGON_RETRIES = 3;
+    protected StopEvent stopEvent;
 
     /**
      * Defines the primary configuration
@@ -126,6 +129,7 @@ public abstract class Client<U, M> implements Codec<U>, Runnable {
             setProtocolName(protocolConfig.getProtocolName());
         }
         setClientConfig(primaryConfig, secondaryConfig);
+        this.stopEvent = new StopEvent(this);
     }
 
     @Override
@@ -343,6 +347,11 @@ public abstract class Client<U, M> implements Codec<U>, Runnable {
         }
     }
 
+    public void initiateStop(){
+        stopEvent.publishStop();
+        stop();
+    }
+
     /**
      * Method to stop client.
      * Must be implemented
@@ -423,6 +432,14 @@ public abstract class Client<U, M> implements Codec<U>, Runnable {
 
     public void setProtocolConfig(ProtocolConfig protocolConfig) {
         this.protocolConfig = protocolConfig;
+    }
+
+    public void addStopEventObserver(StopObserver observer){
+        stopEvent.registerObserver(observer);
+    }
+
+    public void removeStopEventObserver(StopObserver observer){
+        stopEvent.unregisterObserver(observer);
     }
 
     /** Attribute config. */

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/client/ClientFactory.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/client/ClientFactory.java
@@ -2,16 +2,19 @@ package com.neueda.etiqet.core.client;
 
 import com.neueda.etiqet.core.client.delegate.ClientDelegate;
 import com.neueda.etiqet.core.client.delegate.SinkClientDelegate;
+import com.neueda.etiqet.core.client.event.StopObserver;
 import com.neueda.etiqet.core.common.exceptions.EtiqetException;
 import com.neueda.etiqet.core.common.exceptions.UnhandledClientException;
 import com.neueda.etiqet.core.common.exceptions.UnhandledProtocolException;
 import com.neueda.etiqet.core.config.GlobalConfig;
 import com.neueda.etiqet.core.config.dtos.Delegate;
 import com.neueda.etiqet.core.config.dtos.Delegates;
+import com.neueda.etiqet.core.config.dtos.Observer;
+import com.neueda.etiqet.core.config.dtos.StopEvent;
 import com.neueda.etiqet.core.message.config.ProtocolConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Class implementing the factory method pattern to create Clients.
@@ -47,6 +50,7 @@ public class ClientFactory {
 			client.setProtocolName(clientType);
 			client.setUrlExtensions(protocolConfig.getClientUrlExtensions());
             setClientDelegates(client, protocolConfig);
+            setClientStopEventObservers(client, protocolConfig);
 			return client;
         } catch (Exception e) {
             LOG.error(String.format(CLIENT_CREATION_ERROR, clientType), e);
@@ -73,6 +77,7 @@ public class ClientFactory {
             client.setProtocolName(clientType);
             client.setUrlExtensions(protocolConfig.getClientUrlExtensions());
             setClientDelegates(client, protocolConfig);
+            setClientStopEventObservers(client, protocolConfig);
             return client;
         } catch (Exception e) {
             LOG.error(String.format(CLIENT_CREATION_ERROR, clientType), e);
@@ -103,7 +108,8 @@ public class ClientFactory {
             client.setProtocolName(clientType);
             client.setUrlExtensions(protocolConfig.getClientUrlExtensions());
             setClientDelegates(client, protocolConfig);
-			return client;
+            setClientStopEventObservers(client, protocolConfig);
+            return client;
 		} catch (Exception e) {
 			LOG.error(String.format(CLIENT_CREATION_ERROR, clientType), e);
 			throw new UnhandledClientException(String.format(CLIENT_CREATION_ERROR, clientType), e);
@@ -121,6 +127,7 @@ public class ClientFactory {
                                           .getConstructor(String.class, String.class, ProtocolConfig.class)
                                           .newInstance(primaryClientConfig, secondaryClientConfig, protocolConfig);
             setClientDelegates(client, protocolConfig);
+            setClientStopEventObservers(client, protocolConfig);
             return client;
 		} catch (Exception e) {
 		    LOG.error(String.format(CLIENT_CREATION_ERROR, clientClass), e);
@@ -150,6 +157,28 @@ public class ClientFactory {
             }
 
             client.setDelegate(del);
+        }
+    }
+
+	private static void setClientStopEventObservers(Client client, ProtocolConfig protocolConfig) throws EtiqetException{
+        StopEvent event = protocolConfig.getStopEvent();
+        if (event != null){
+            for (Observer observer: event.getObservers()){
+                StopObserver observerImpl;
+                try{
+                    observerImpl = (StopObserver) Class.forName(observer.getImpl()).getConstructor().newInstance();
+                } catch (ClassNotFoundException e){
+                    throw new EtiqetException(
+                            String.format("Can't find StopObserver impl '%s'\n\t%s", observer.getImpl(), e.getMessage())
+                    );
+                }
+                catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e){
+                    throw new EtiqetException(
+                            String.format("Failed to instantiate '%s'\n\t%s", observer.getImpl(), e.getMessage())
+                    );
+                }
+                client.addStopEventObserver(observerImpl);
+            }
         }
     }
 

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/client/event/Event.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/client/event/Event.java
@@ -1,0 +1,28 @@
+package com.neueda.etiqet.core.client.event;
+
+import com.neueda.etiqet.core.client.Client;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class Event <Observer>{
+    protected Client client;
+
+    public Event(Client client){
+        this.client = client;
+    }
+
+    protected final Set<Observer> mObservers = Collections.newSetFromMap(new ConcurrentHashMap<Observer, Boolean>(0));
+
+    public void registerObserver(Observer observer) {
+        if (observer == null) return;
+        mObservers.add(observer);
+    }
+
+    public void unregisterObserver(Observer observer) {
+        if (observer != null) {
+            mObservers.remove(observer);
+        }
+    }
+}

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/client/event/StopEvent.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/client/event/StopEvent.java
@@ -1,0 +1,24 @@
+package com.neueda.etiqet.core.client.event;
+
+import com.neueda.etiqet.core.client.Client;
+import com.neueda.etiqet.core.common.exceptions.EtiqetException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class StopEvent extends Event<StopObserver> {
+    private static final Logger LOG = LogManager.getLogger(StopEvent.class.getName());
+
+    public StopEvent(Client client) {
+        super(client);
+    }
+
+    public void publishStop(){
+        for(StopObserver observer: mObservers){
+            try {
+                observer.handleStop(client);
+            } catch (EtiqetException e) {
+                LOG.warn(String.format("StopObserver '%s' threw Exception:\n\t%s", observer.getClass(), e.getMessage()));
+            }
+        }
+    }
+}

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/client/event/StopObserver.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/client/event/StopObserver.java
@@ -1,0 +1,8 @@
+package com.neueda.etiqet.core.client.event;
+
+import com.neueda.etiqet.core.client.Client;
+import com.neueda.etiqet.core.common.exceptions.EtiqetException;
+
+public abstract class StopObserver {
+    public abstract void handleStop(Client client) throws EtiqetException;
+}

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/config/dtos/Client.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/config/dtos/Client.java
@@ -23,6 +23,8 @@ public class Client implements Serializable {
 
 	private Delegates delegates;
 
+	private StopEvent stopEvent;
+
 	@XmlElement(name = "delegates", namespace = EtiqetConstants.NAMESPACE)
 	public Delegates getDelegates() {
 		return delegates;
@@ -30,6 +32,15 @@ public class Client implements Serializable {
 
 	public void setDelegates(Delegates delegates) {
 		this.delegates = delegates;
+	}
+
+	@XmlElement(name = "stopEvent", namespace = EtiqetConstants.NAMESPACE)
+	public StopEvent getStopEvent() {
+		return stopEvent;
+	}
+
+	public void setStopEvent(StopEvent stopEvent) {
+		this.stopEvent = stopEvent;
 	}
 
 	@XmlAttribute(required = true)

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/config/dtos/Observer.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/config/dtos/Observer.java
@@ -1,0 +1,21 @@
+package com.neueda.etiqet.core.config.dtos;
+
+import com.neueda.etiqet.core.common.EtiqetConstants;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+@XmlRootElement(namespace = EtiqetConstants.NAMESPACE)
+public class Observer implements Serializable {
+    private String impl;
+
+    @XmlAttribute
+    public String getImpl() {
+        return impl;
+    }
+
+    public void setImpl(String impl) {
+        this.impl = impl;
+    }
+}

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/config/dtos/StopEvent.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/config/dtos/StopEvent.java
@@ -1,0 +1,26 @@
+package com.neueda.etiqet.core.config.dtos;
+
+import com.neueda.etiqet.core.common.EtiqetConstants;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+@XmlRootElement(namespace = EtiqetConstants.NAMESPACE)
+public class StopEvent implements Serializable {
+    private Observer[] observers;
+
+    @XmlElement(name = "observer", namespace = EtiqetConstants.NAMESPACE)
+    public Observer[] getObservers() {
+        return observers;
+    }
+
+    public void setObservers(Observer[] observers) {
+        this.observers = observers;
+    }
+
+    @Override
+    public String toString() {
+        return "StopEvent [observers = " + observers + "]";
+    }
+}

--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/message/config/ProtocolConfig.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/message/config/ProtocolConfig.java
@@ -130,6 +130,10 @@ public class ProtocolConfig implements Serializable {
 		return getProtocol().getClient().getDelegates();
 	}
 
+	public StopEvent getStopEvent(){
+		return getProtocol().getClient().getStopEvent();
+	}
+
 	public List<UrlExtension> getClientUrlExtensions(){
 		return getProtocol().getClient().getUrlExtensions();
 	}

--- a/etiqet-core/src/main/java/com/neueda/etiqet/fixture/EtiqetHandlers.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/fixture/EtiqetHandlers.java
@@ -832,7 +832,7 @@ public class EtiqetHandlers {
         Client client = getClient(clientName);
         assertNotNull(String.format(ERROR_CLIENT_NOT_FOUND, clientName), client);
 
-        client.stop();
+        client.initiateStop();
     }
 
     /**
@@ -1192,7 +1192,7 @@ public class EtiqetHandlers {
         try {
             // Stop all clients using lambda expressions.
             if (!ArrayUtils.isNullOrEmpty(clientMap)) {
-                clientMap.values().forEach(Client::stop);
+                clientMap.values().forEach(Client::initiateStop);
             }
         } catch (Exception lex) {
             // Log the caught exception.

--- a/etiqet-core/src/main/resources/etiqet.protocol.xsd
+++ b/etiqet-core/src/main/resources/etiqet.protocol.xsd
@@ -218,6 +218,16 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="stopEvent" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>List of observers to be notified when a client is stopped.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="observer" maxOccurs="unbounded" type="Observer"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="urlExtensions" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>List of Api extensions for the client to use.</xs:documentation>
@@ -282,7 +292,16 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
-
+    <xs:complexType name="Observer">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Executes logic on event trigger</xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="impl" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Fully qualified class name of the Observer class</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
     <xs:complexType name="Dictionary">
         <xs:annotation>
             <xs:documentation xml:lang="en">Describes the dictionary class of message types.</xs:documentation>

--- a/etiqet-fix/src/main/java/com/neueda/etiqet/fix/client/FixApp.java
+++ b/etiqet-fix/src/main/java/com/neueda/etiqet/fix/client/FixApp.java
@@ -77,9 +77,14 @@ public class FixApp extends MessageCracker implements Application {
 
     private void receiveMsg(BlockingQueue<Cdr> queue, Message msg) {
         try {
-            Cdr cdr = new Cdr(msg.getHeader().getString(35));
-            cdr.update(delegate.transformAfterReceiveMessage(FIXUtils.decode(delegate.transformAfterDecoding(msg))));
-            queue.add(cdr);
+            Cdr message = FIXUtils.decode(delegate.transformAfterDecoding(msg));
+            message = delegate.transformAfterReceiveMessage(message);
+
+            if (message != null){
+                Cdr cdr = new Cdr(msg.getHeader().getString(35));
+                cdr.update(message);
+                queue.add(cdr);
+            }
         } catch (Exception e) {
             throw new EtiqetRuntimeException(e);
         }


### PR DESCRIPTION
StopObservers defined in etiqet.config.xml will be alerted before a Client stops
Enables adding some cleanup logic such as sending cancels for fix orders which have not been filled 