### PR TITLE
Handlers get response made public

### DIFF
--- a/etiqet-core/src/main/java/com/neueda/etiqet/fixture/EtiqetHandlers.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/fixture/EtiqetHandlers.java
@@ -760,7 +760,7 @@ public class EtiqetHandlers {
         assertNotNull(getResponse(messageName));
     }
 
-    Cdr getResponse(String messageName) {
+    public Cdr getResponse(String messageName) {
         return responseMap.get(messageName);
     }
 


### PR DESCRIPTION
Want to access stored responses outside of com.neueda.etiqet.fixture package