### PR TITLE
JMS transport added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 cache:
     directories:
         - "$HOME/.m2"
+script: mvn clean test -B
 notifications:
     webhooks:
         secure: VOulY4tAbu0wTcdWF4nD+OjPz02E3iiPJSx63HrIorNe5N8snydrcG68Ex8UZ5BNMZwvGeNadXAeweY0o14jh67zSoe4dCq/HjCyxEsnvn+KkF518qJZFNR8p720UzWwffAAHteUTwUlysMjLcpBFHjsZ3scAgjUhtpFQXf5/5nhvwUITt/jXhCwBgxFnWL1Ee1bR6jwS6yvQ9Y8nY9TD6D60eQo/2uv5wk4HU9PymCMVu9RvtZkrzcie1w42kugHmNmaJagXamQ3ISV1f6QJ80DNBb+j1kMv8MR64oXA5ShNb7UvuZZHvKZ7no5k/V9eQ+GbRRzg/09HtKujXoNRvxvqLUWryVTLIAnQ3jQUwKTHxECpjddxFXabcV0QqzmT84wr199BFSjQL4VOciIP4ZdguCjj0WMPwwtvKmn165IDNasvYrTryGVhx+ElkVuVJn8zKHK1UyXuEsoA6buuThGF2ZXGJzS4r2/RCr0wphkO7wE3wFQaP3EQYpNgxnVG4ffdQXvWitzjdk3c4rhxIR8TiMT+K7L8q9wTew1VX06DY9z0asZGb21QX1EtFO6L3FkzRdGut4SNZDoLLSxBOwTg/VDmuTCW/tEP8XeSiEtSfvPJ4B3XpLIwkHlYuGIsoKFVs96C7YaOygWeMdy4m6wQQT78kwRco8758jgVPo=

--- a/etiqet-transport-jms/pom.xml
+++ b/etiqet-transport-jms/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>etiqet-parent</artifactId>
+        <groupId>com.neueda.etiqet</groupId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>etiqet-transport-jms</artifactId>
+    <properties>
+        <jms.version>2.0.1</jms.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.neueda.etiqet</groupId>
+            <artifactId>etiqet-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.jms</groupId>
+            <artifactId>javax.jms-api</artifactId>
+            <version>${jms.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.15.9</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <xjbSources>
+                        <xjbSource>src/main/resources/global.xjb</xjbSource>
+                    </xjbSources>
+                    <sources>
+                        <source>src/main/resources/etiqet_jms.xsd</source>
+                    </sources>
+                    <staleFileDirectory>${project.build.directory}/generated-sources</staleFileDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/etiqet-transport-jms/pom.xml
+++ b/etiqet-transport-jms/pom.xml
@@ -60,7 +60,6 @@
                     <sources>
                         <source>src/main/resources/etiqet_jms.xsd</source>
                     </sources>
-                    <staleFileDirectory>${project.build.directory}/generated-sources</staleFileDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/ArgumentType.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/ArgumentType.java
@@ -1,0 +1,24 @@
+package com.neueda.etiqet.transport.jms;
+
+import com.neueda.etiqet.core.common.exceptions.EtiqetRuntimeException;
+
+public enum ArgumentType {
+    STRING (String.class);
+
+    private Class clazz;
+
+    ArgumentType(final Class clazz)  {
+        this.clazz = clazz;
+    }
+
+    public Class getClazz() {
+        return clazz;
+    }
+
+   public static ArgumentType from(final String propertyType) {
+        switch (propertyType) {
+            case "string": return STRING;
+            default: throw new EtiqetRuntimeException("Invalid constructor argument property type " + propertyType);
+        }
+    }
+}

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/ConstructorArgument.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/ConstructorArgument.java
@@ -1,0 +1,27 @@
+package com.neueda.etiqet.transport.jms;
+
+public class ConstructorArgument {
+    private ArgumentType argumentType;
+    private Object value;
+
+    public ConstructorArgument(ArgumentType argumentType, Object value) {
+        this.argumentType = argumentType;
+        this.value = value;
+    }
+
+    public ArgumentType getArgumentType() {
+        return argumentType;
+    }
+
+    public void setArgumentType(ArgumentType argumentType) {
+        this.argumentType = argumentType;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/JmsConfigConstants.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/JmsConfigConstants.java
@@ -1,0 +1,6 @@
+package com.neueda.etiqet.transport.jms;
+
+public class JmsConfigConstants {
+
+    public static final String JMS_CONFIG_SCHEMA = "etiqet_jms.xsd";
+}

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/JmsTransport.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/JmsTransport.java
@@ -1,0 +1,304 @@
+package com.neueda.etiqet.transport.jms;
+
+import com.neueda.etiqet.core.client.delegate.ClientDelegate;
+import com.neueda.etiqet.core.common.exceptions.EtiqetException;
+import com.neueda.etiqet.core.common.exceptions.EtiqetRuntimeException;
+import com.neueda.etiqet.core.message.cdr.Cdr;
+import com.neueda.etiqet.core.transport.Codec;
+import com.neueda.etiqet.core.transport.Transport;
+import com.neueda.etiqet.core.transport.TransportDelegate;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.jms.*;
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import static com.neueda.etiqet.transport.jms.JmsConfigConstants.JMS_CONFIG_SCHEMA;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Class used to interact with a jms bus
+ */
+public class JmsTransport implements Transport {
+
+    private final static Logger logger = LoggerFactory.getLogger(JmsTransport.class);
+
+    private ConnectionFactory connectionFactory;
+    private Connection connection;
+    private Session session;
+    private Codec<Cdr, String> codec;
+    private String defaultTopic;
+    private ClientDelegate delegate;
+    private TransportDelegate<String, Cdr> transDel;
+
+    /**
+     * Instantiates a Jms connection factory and determines the default topic to publish messages to
+     *
+     * @param configPath Path to the jms configuration
+     * @throws EtiqetException when we're unable to read the configuration file
+     */
+    @Override
+    public void init(String configPath) throws EtiqetException {
+        JmsConfiguration configuration = getJmsConfiguration(configPath);
+        connectionFactory = createConnectionFactory(configuration);
+        defaultTopic = configuration.getDefaultTopic();
+    }
+
+    private JmsConfiguration getJmsConfiguration(final String configPath) throws EtiqetException {
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(JmsConfiguration.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            URL protocolSchema = getClass().getClassLoader().getResource(JMS_CONFIG_SCHEMA);
+            if (protocolSchema == null) {
+                throw new EtiqetException("Unable to find configuration schema " + JMS_CONFIG_SCHEMA);
+            }
+            Schema schema = sf.newSchema(protocolSchema);
+            unmarshaller.setSchema(schema);
+            return (JmsConfiguration) unmarshaller.unmarshal(new File(configPath));
+        } catch (JAXBException | SAXException e) {
+            throw new EtiqetException("Error retrieving Jms configuration from " + configPath, e);
+        }
+    }
+
+    private ConnectionFactory createConnectionFactory(final JmsConfiguration configuration) throws EtiqetException {
+        List<ConstructorArgument> constructorArguments = getConstructorArguments(configuration.getConstructorArgs());
+        final Class[] argumentClasses = constructorArguments.stream()
+            .map(arg -> arg.getArgumentType().getClazz())
+            .toArray(Class[]::new);
+        final Object[] argumentValues = constructorArguments.stream()
+            .map(ConstructorArgument::getValue)
+            .toArray(Object[]::new);
+
+        try {
+            final Class<?> constructorClass = Class.forName(configuration.getImplementation());
+            final ConnectionFactory cf = (ConnectionFactory) constructorClass.getConstructor(argumentClasses).newInstance(argumentValues);
+            getSetterArguments(configuration.getProperties()).forEach(
+                setterArgument -> setArgument(setterArgument, constructorClass, cf)
+            );
+            return cf;
+        } catch (ReflectiveOperationException e) {
+            throw new EtiqetException(e.getMessage());
+        }
+
+    }
+
+    private void setArgument(final SetterArgument setterArgument, final Class<?> clazz, final ConnectionFactory connectionFactory) {
+        try {
+            Method method = clazz.getDeclaredMethod("set" + StringUtils.capitalize(setterArgument.getName()), setterArgument.getArgumentType().getClazz());
+            method.invoke(connectionFactory, setterArgument.getValue());
+        } catch (ReflectiveOperationException e) {
+            throw new EtiqetRuntimeException("Invalid setter property for connection factory with name " + setterArgument.getName());
+        }
+    }
+
+    private List<ConstructorArgument> getConstructorArguments(final ConstructorArgs constructorArgs) {
+        if (constructorArgs == null) {
+            return Collections.emptyList();
+        }
+        return constructorArgs.getArg().stream()
+            .map(this::mapArgument)
+            .collect(toList());
+    }
+
+    private ConstructorArgument mapArgument(final ConstructorArg xmlArg) {
+        return new ConstructorArgument(
+            ArgumentType.from(xmlArg.getArgType().value()),
+            xmlArg.getArgValue()
+        );
+    }
+
+
+    private List<SetterArgument> getSetterArguments(final Properties properties) {
+        if (properties == null) {
+            return Collections.emptyList();
+        }
+        return properties.getProperty().stream()
+            .map(this::mapProperty)
+            .collect(toList());
+    }
+
+    private SetterArgument mapProperty(SetterProperty prop) {
+        return new SetterArgument(
+            ArgumentType.from(prop.getArgType().value()),
+            prop.getArgName(),
+            prop.getArgValue()
+        );
+    }
+
+    /**
+     * Starts a connection to the configured Jms bus
+     *
+     * @throws EtiqetException when unable to create a connection or session on the Jms bus
+     */
+    @Override
+    public void start() throws EtiqetException {
+        try {
+            connection = connectionFactory.createConnection();
+            connection.start();
+            session = connection.createSession(true, Session.AUTO_ACKNOWLEDGE);
+        } catch (JMSException e) {
+            throw new EtiqetException("Couldn't create Jms connection", e);
+        }
+    }
+
+    /**
+     * Stops the Jms bus connection and session
+     */
+    @Override
+    public void stop() {
+        if (session != null) {
+            try {
+                session.close();
+            } catch (JMSException e) {
+                logger.error("Couldn't safely stop Jms session", e);
+            } finally {
+                session = null;
+            }
+        }
+
+        if (connection != null) {
+            try {
+                connection.stop();
+            } catch (JMSException e) {
+                logger.error("Couldn't safely stop Jms connection", e);
+            } finally {
+                connection = null;
+            }
+        }
+    }
+
+    /**
+     * Sends a message to the Jms bus on the default topic provided in the configuration file
+     *
+     * @param msg message to be sent
+     * @throws EtiqetException When an error occurs sending the message
+     */
+    @Override
+    public void send(Cdr msg) throws EtiqetException {
+        send(msg, getDefaultSessionId());
+    }
+
+    /**
+     * Sends a message to the Jms bus on the default topic provided
+     *
+     * @param msg       message to be sent
+     * @param topicName String containing the topic
+     * @throws EtiqetException When an error occurs sending the message
+     */
+    @Override
+    public void send(Cdr msg, String topicName) throws EtiqetException {
+        if (StringUtils.isEmpty(topicName)) {
+            logger.info("Empty topic name passed for sending to Jms, using default topic from config: {}", defaultTopic);
+            topicName = getDefaultSessionId();
+        }
+        if (StringUtils.isEmpty(topicName)) {
+            throw new EtiqetException("Unable to send message without a defined topic");
+        }
+        try {
+            MessageProducer producer = session.createProducer(session.createTopic(topicName));
+            producer.send(session.createTextMessage(codec.encode(msg)));
+        } catch (JMSException e) {
+            logger.error("Exception sending message to Jms bus.", e);
+            throw new EtiqetException(e);
+        }
+    }
+
+    /**
+     * @return whether a connection is established to the jms bus
+     */
+    @Override
+    public boolean isLoggedOn() {
+        return connection != null;
+    }
+
+    /**
+     * @return the default topic to send messages to
+     */
+    @Override
+    public String getDefaultSessionId() {
+        return defaultTopic;
+    }
+
+    /**
+     * @param transDel the transport delegate class
+     */
+    @Override
+    public void setTransportDelegate(TransportDelegate<String, Cdr> transDel) {
+        this.transDel = transDel;
+    }
+
+    /**
+     * @param c the codec used by the transport.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setCodec(Codec c) {
+        this.codec = c;
+    }
+
+    /**
+     * @return the codec used by the transport.
+     */
+    @Override
+    public Codec getCodec() {
+        return codec;
+    }
+
+    /**
+     * @param delegate the first client delegate of a chain to use (if any)
+     */
+    @Override
+    public void setDelegate(ClientDelegate delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * @return the first client delegate of a chain to be used (if any)
+     */
+    @Override
+    public ClientDelegate getDelegate() {
+        return delegate;
+    }
+
+    ConnectionFactory getConnectionFactory() {
+        return connectionFactory;
+    }
+
+    void setConnectionFactory(ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    Connection getConnection() {
+        return connection;
+    }
+
+    void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    Session getSession() {
+        return session;
+    }
+
+    void setSession(Session session) {
+        this.session = session;
+    }
+
+    void setDefaultTopic(String defaultTopic) {
+        this.defaultTopic = defaultTopic;
+    }
+
+}

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/SetterArgument.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/SetterArgument.java
@@ -1,0 +1,37 @@
+package com.neueda.etiqet.transport.jms;
+
+public class SetterArgument {
+    private ArgumentType argumentType;
+    private String name;
+    private String value;
+
+    public SetterArgument(ArgumentType argumentType, String name, String value) {
+        this.argumentType = argumentType;
+        this.name = name;
+        this.value = value;
+    }
+
+    public ArgumentType getArgumentType() {
+        return argumentType;
+    }
+
+    public void setArgumentType(ArgumentType argumentType) {
+        this.argumentType = argumentType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/etiqet-transport-jms/src/main/resources/etiqet_jms.xsd
+++ b/etiqet-transport-jms/src/main/resources/etiqet_jms.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<xs:schema targetNamespace="http://www.neueda.com/etiqet/transport/jms"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.neueda.com/etiqet/transport/jms">
+
+    <xs:element name="jmsConfiguration">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="constructor-args" type="ConstructorArgs" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="properties" type="Properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="implementation" type="xs:string" use="required"/>
+            <xs:attribute name="defaultTopic" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="ConstructorArgs">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="arg" type="ConstructorArg"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ConstructorArg">
+        <xs:attribute name="argType" type="ArgType"/>
+        <xs:attribute name="argValue" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="Properties">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="property" type="SetterProperty"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="SetterProperty">
+        <xs:attribute name="argType" type="ArgType"/>
+        <xs:attribute name="argName" type="xs:string" />
+        <xs:attribute name="argValue" type="xs:string" />
+    </xs:complexType>
+
+    <xs:simpleType name="ArgType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="string"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/etiqet-transport-jms/src/main/resources/global.xjb
+++ b/etiqet-transport-jms/src/main/resources/global.xjb
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings version="2.1"
+               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb
+                                   http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd">
+
+    <jaxb:globalBindings localScoping="toplevel">
+        <jaxb:serializable uid="1"/>
+
+        <!-- date time adapter -->
+       <!-- <jaxb:javaType name="java.util.Calendar" xmlType="xs:dateTime"
+                       parseMethod="javax.xml.bind.DatatypeConverter.parseDateTime"
+                       printMethod="javax.xml.bind.DatatypeConverter.printDateTime" />-->
+
+    </jaxb:globalBindings>
+
+</jaxb:bindings>

--- a/etiqet-transport-jms/src/test/java/com/neueda/etiqet/jms/JmsTest.java
+++ b/etiqet-transport-jms/src/test/java/com/neueda/etiqet/jms/JmsTest.java
@@ -1,0 +1,19 @@
+package com.neueda.etiqet.jms;
+
+import com.neueda.etiqet.core.EtiqetOptions;
+import com.neueda.etiqet.core.EtiqetTestRunner;
+import org.junit.runner.RunWith;
+
+/**
+ * This class class the basic jms_test.feature in the test classpath. This feature requires a running Jms instance
+ * so the feature has been commented out to prevent build failures. The feature remains as an indication of Etiqet
+ * fixtures that can be used to interact with a Jms bus.
+ */
+@RunWith(EtiqetTestRunner.class)
+@EtiqetOptions(
+    configFile = "src/test/resources/config/etiqet.config.xml",
+    plugin = {"pretty", "html:target/cucumber"},
+    features = "src/test/resources/features/jms_test.feature"
+)
+public class JmsTest {
+}

--- a/etiqet-transport-jms/src/test/java/com/neueda/etiqet/transport/jms/JmsTransportTest.java
+++ b/etiqet-transport-jms/src/test/java/com/neueda/etiqet/transport/jms/JmsTransportTest.java
@@ -1,0 +1,277 @@
+package com.neueda.etiqet.transport.jms;
+
+import com.neueda.etiqet.core.common.exceptions.EtiqetException;
+import com.neueda.etiqet.core.message.cdr.Cdr;
+import com.neueda.etiqet.core.transport.Codec;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+public class JmsTransportTest {
+
+    private JmsTransport transport;
+
+    @Before
+    public void setUp() {
+        transport = new JmsTransport();
+    }
+
+    @After
+    public void tearDown() {
+        transport = null;
+    }
+
+    @Test
+    public void testInit() throws EtiqetException {
+        transport.init("src/test/resources/config/jmsConfig.xml");
+        ActiveMQConnectionFactory connectionFactory = (ActiveMQConnectionFactory) transport.getConnectionFactory();
+        assertNotNull("Connection Factory should exist after transport is initialised", connectionFactory);
+        assertEquals("tcp://localhost:61616", connectionFactory.getBrokerURL());
+        assertEquals("USERNAME", connectionFactory.getUserName());
+        assertEquals("PASSWORD", connectionFactory.getPassword());
+        assertEquals("testTopic", transport.getDefaultSessionId());
+    }
+
+    @Test
+    public void testInit_PropertiesNotFound() {
+        String configPath = "src/test/resources/config/jms_config_not_found.xml";
+        try {
+            transport.init(configPath);
+            fail("Should have failed because the above config file shouldn't exist");
+        } catch (Exception e) {
+            assertTrue(e instanceof EtiqetException);
+            assertEquals("Error retrieving Jms configuration from " + configPath , e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInit_invalidXmlConfiguration() {
+        String configPath = "src/test/resources/config/jmsConfig_invalid.xml";
+        try {
+            transport.init(configPath);
+            fail("Should have failed because the above config file is not valid");
+        } catch (Exception e) {
+            assertTrue(e instanceof EtiqetException);
+            assertEquals("Error retrieving Jms configuration from " + configPath , e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInit_propertiesMissingInConfiguration() throws EtiqetException{
+        String configPath = "src/test/resources/config/jmsConfig_missingProperties.xml";
+        transport.init(configPath);
+    }
+
+    @Test
+    public void testStart() throws JMSException, EtiqetException {
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        Connection connection = mock(Connection.class);
+        Session session = mock(Session.class);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
+        when(connectionFactory.createConnection()).thenReturn(connection);
+
+        transport.setConnectionFactory(connectionFactory);
+
+        assertNull(transport.getConnection());
+        assertFalse(transport.isLoggedOn());
+        assertNull(transport.getSession());
+        transport.start();
+        assertEquals(connectionFactory, transport.getConnectionFactory());
+        assertEquals(connection, transport.getConnection());
+        assertTrue(transport.isLoggedOn());
+        assertEquals(session, transport.getSession());
+
+        verify(connectionFactory, times(1)).createConnection();
+        verify(connection, times(1)).start();
+        verify(connection, times(1)).createSession(eq(true), eq(Session.AUTO_ACKNOWLEDGE));
+        verifyNoMoreInteractions(connectionFactory, connection);
+    }
+
+    @Test
+    public void testStart_CannotCreateSession() throws JMSException {
+        ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+        Connection connection = mock(Connection.class);
+        when(connection.createSession(anyBoolean(), anyInt())).thenThrow(new JMSException("Unable to create session"));
+        when(connectionFactory.createConnection()).thenReturn(connection);
+
+        transport.setConnectionFactory(connectionFactory);
+
+        try {
+            assertNull(transport.getConnection());
+            assertFalse(transport.isLoggedOn());
+            assertNull(transport.getSession());
+            transport.start();
+            fail("Should have thrown an exception because we couldn't create a session");
+        } catch (Exception e) {
+            assertTrue(e instanceof EtiqetException);
+            assertEquals("Couldn't create Jms connection", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testStop() throws JMSException {
+        Connection connection = mock(Connection.class);
+        Session session = mock(Session.class);
+
+        transport.setConnection(connection);
+        transport.setSession(session);
+        transport.stop();
+        verify(connection, times(1)).stop();
+        verify(session, times(1)).close();
+        verifyNoMoreInteractions(connection, session);
+    }
+
+    @Test
+    public void testStop_NoSessionNoConnection() {
+        assertNull(transport.getConnection());
+        assertFalse(transport.isLoggedOn());
+        assertNull(transport.getSession());
+        transport.stop();
+        assertNull(transport.getConnection());
+        assertFalse(transport.isLoggedOn());
+        assertNull(transport.getSession());
+    }
+
+    @Test
+    public void testStop_SessionCloseException() throws JMSException {
+        Connection connection = mock(Connection.class);
+        Session session = mock(Session.class);
+        doThrow(new JMSException("Unable to close session")).when(session).close();
+
+        transport.setConnection(connection);
+        transport.setSession(session);
+        transport.stop();
+        assertNull(transport.getConnection());
+        assertFalse(transport.isLoggedOn());
+        assertNull(transport.getSession());
+
+        verify(connection, times(1)).stop();
+        verify(session, times(1)).close();
+        verifyNoMoreInteractions(connection, session);
+    }
+
+    @Test
+    public void testStop_ConnectionCloseException() throws JMSException {
+        Connection connection = mock(Connection.class);
+        Session session = mock(Session.class);
+        doThrow(new JMSException("Unable to close session")).when(connection).stop();
+
+        transport.setConnection(connection);
+        transport.setSession(session);
+        transport.stop();
+        assertNull(transport.getConnection());
+        assertFalse(transport.isLoggedOn());
+        assertNull(transport.getSession());
+
+        verify(connection, times(1)).stop();
+        verify(session, times(1)).close();
+        verifyNoMoreInteractions(connection, session);
+    }
+
+    @Test
+    public void testSend_WithTopic() throws EtiqetException, JMSException {
+        String testText = "TEST";
+        Cdr testCdr = new Cdr("TEST");
+        Codec<Cdr, String> codec = new Codec<Cdr, String>() {
+            @Override
+            public String encode(Cdr message) {
+                return testText;
+            }
+
+            @Override
+            public Cdr decode(String message) {
+                return testCdr;
+            }
+        };
+
+        Session session = mock(Session.class);
+        Topic topic = mock(Topic.class);
+        when(session.createTopic(anyString())).thenReturn(topic);
+        MessageProducer producer = mock(MessageProducer.class);
+        when(session.createProducer(eq(topic))).thenReturn(producer);
+        TextMessage message = mock(TextMessage.class);
+        when(session.createTextMessage(eq(testText))).thenReturn(message);
+
+        transport.setCodec(codec);
+        transport.setSession(session);
+        transport.send(testCdr, "TestTopic");
+        verify(session, times(1)).createTopic(eq("TestTopic"));
+        verify(session, times(1)).createProducer(eq(topic));
+        verify(session, times(1)).createTextMessage(eq(testText));
+        verify(producer, times(1)).send(eq(message));
+        verifyNoMoreInteractions(session, producer);
+    }
+
+    @Test
+    public void testSend_WithDefaultTopic() throws EtiqetException, JMSException {
+        String testText = "TEST";
+        Cdr testCdr = new Cdr("TEST");
+        Codec<Cdr, String> codec = new Codec<Cdr, String>() {
+            @Override
+            public String encode(Cdr message) {
+                return testText;
+            }
+
+            @Override
+            public Cdr decode(String message) {
+                return testCdr;
+            }
+        };
+
+        Session session = mock(Session.class);
+        Topic topic = mock(Topic.class);
+        when(session.createTopic(anyString())).thenReturn(topic);
+        MessageProducer producer = mock(MessageProducer.class);
+        when(session.createProducer(eq(topic))).thenReturn(producer);
+        TextMessage message = mock(TextMessage.class);
+        when(session.createTextMessage(eq(testText))).thenReturn(message);
+
+        transport.setCodec(codec);
+        transport.setSession(session);
+        transport.setDefaultTopic("TestTopic");
+        transport.send(testCdr);
+        verify(session, times(1)).createTopic(eq("TestTopic"));
+        verify(session, times(1)).createProducer(eq(topic));
+        verify(session, times(1)).createTextMessage(eq(testText));
+        verify(producer, times(1)).send(eq(message));
+        verifyNoMoreInteractions(session, producer);
+    }
+
+    @Test
+    public void testSend_NoTopicProvided() {
+        Cdr testCdr = new Cdr("TEST");
+        transport.setDefaultTopic("");
+        try {
+            transport.send(testCdr, null);
+            fail("Should have failed because no viable topic was provided");
+        } catch (Exception e) {
+            assertTrue(e instanceof EtiqetException);
+            assertEquals("Unable to send message without a defined topic", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSend_CannotCreateProducer() throws JMSException {
+        Session session = mock(Session.class);
+        Topic topic = mock(Topic.class);
+        when(session.createTopic(anyString())).thenReturn(topic);
+        when(session.createProducer(eq(topic))).thenThrow(new JMSException("Unable to create Jms Producer"));
+        try {
+            transport.setSession(session);
+            transport.send(new Cdr("TEST"), "TestTopic");
+            fail("Should have failed because and exception should have been thrown while creating the producer");
+        } catch (Exception e) {
+            assertTrue(e instanceof EtiqetException);
+            assertEquals("javax.jms.JMSException: Unable to create Jms Producer", e.getMessage());
+        }
+    }
+
+}

--- a/etiqet-transport-jms/src/test/resources/config/etiqet.config.xml
+++ b/etiqet-transport-jms/src/test/resources/config/etiqet.config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etiqetConfiguration xmlns="http://www.neueda.com/etiqet">
+    <protocols>
+        <protocol name="jms">
+            <client defaultConfig="${user.dir}/src/test/resources/config/jmsConfig.xml"
+                    impl = "com.neueda.etiqet.core.client.GenericClient"
+                    transportImpl="com.neueda.etiqet.transport.jms.JmsTransport"
+                    codecImpl="com.neueda.etiqet.core.json.JsonCodec">
+            </client>
+            <messages>
+                <message name="TestMessage">
+                    <implementation>java.lang.String</implementation>
+                </message>
+            </messages>
+        </protocol>
+    </protocols>
+</etiqetConfiguration>

--- a/etiqet-transport-jms/src/test/resources/config/jmsConfig.xml
+++ b/etiqet-transport-jms/src/test/resources/config/jmsConfig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e:jmsConfiguration implementation="org.apache.activemq.ActiveMQConnectionFactory"
+                  defaultTopic="testTopic"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:e="http://www.neueda.com/etiqet/transport/jms">
+    <constructor-args>
+        <arg argType="string" argValue="tcp://localhost:61616"/>
+    </constructor-args>
+    <properties>
+        <property argType="string" argName="userName" argValue="USERNAME"/>
+        <property argType="string" argName="password" argValue="PASSWORD"/>
+    </properties>
+</e:jmsConfiguration>

--- a/etiqet-transport-jms/src/test/resources/config/jmsConfig_invalid.xml
+++ b/etiqet-transport-jms/src/test/resources/config/jmsConfig_invalid.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e:jmsConfiguration implementation="org.apache.activemq.ActiveMQConnectionFactory"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:e="http://www.neueda.com/etiqet/transport/jms">
+    <!--defaultTopic="testTopic"-->
+    <constructor-args>
+        <arg argType="string" argValue="tcp://localhost:61616"/>
+    </constructor-args>
+    <properties>
+        <property argType="string" argName="userName" argValue="USERNAME"/>
+        <property argType="string" argName="password" argValue="PASSWORD"/>
+    </properties>
+</e:jmsConfiguration>

--- a/etiqet-transport-jms/src/test/resources/config/jmsConfig_missingProperties.xml
+++ b/etiqet-transport-jms/src/test/resources/config/jmsConfig_missingProperties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<e:jmsConfiguration implementation="org.apache.activemq.ActiveMQConnectionFactory"
+                  defaultTopic="testTopic"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:e="http://www.neueda.com/etiqet/transport/jms">
+    <constructor-args>
+        <arg argType="string" argValue="tcp://localhost:61616"/>
+    </constructor-args>
+<!--    <properties>
+        <property argType="string" argName="userName" argValue="USERNAME"/>
+        <property argType="string" argName="password" argValue="PASSWORD"/>
+    </properties>-->
+</e:jmsConfiguration>

--- a/etiqet-transport-jms/src/test/resources/features/jms_test.feature
+++ b/etiqet-transport-jms/src/test/resources/features/jms_test.feature
@@ -1,0 +1,7 @@
+Feature: Jms Testing
+
+#    Scenario: Connection Test
+#        Given a "jms" client as "jms_client"
+#        And client "jms_client" is started
+#        Then wait for 2 seconds
+#        And send an "TestMessage" "jms" message with "Test=Value" using "jms_client" with session id "testTopic"

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>etiqet-websocket</module>
         <module>etiqet-selenium</module>
         <module>etiqet-transport-qfj</module>
+        <module>etiqet-transport-jms</module>
         <module>etiqet-transport-rabbitmq-gpb</module>
         <module>etiqet-transport-solace</module>
     </modules>


### PR DESCRIPTION
The main idea behind this pull request is to replace the transport-solace module by a generic JMS one instead.
The connection factory is created using reflection, passed using the new XML configuration schema (rather than a properties file). In that xml you can specify constructor arguments as well as setters