### PR TITLE
binary conversion delegate added to jms transport

### DIFF
--- a/etiqet-core/src/main/java/com/neueda/etiqet/core/client/Client.java
+++ b/etiqet-core/src/main/java/com/neueda/etiqet/core/client/Client.java
@@ -303,10 +303,10 @@ public abstract class Client implements Transport, Runnable {
       }
       setTransport((Transport) Class.forName(protocolConfig.getClient().getTransportImpl())
           .newInstance());
-      transport.init(config);
-      transport.setDelegate(delegate);
       AbstractDictionary dictionary = protocolConfig.getDictionary();
       transport.setDictionary(dictionary);
+      transport.init(config);
+      transport.setDelegate(delegate);
       Codec codec = (Codec) Class.forName(protocolConfig.getClient().getCodecImpl()).newInstance();
       codec.setDictionary(dictionary);
       setCodec(codec);

--- a/etiqet-exchange-broker/src/test/resources/features/exchange_test.feature
+++ b/etiqet-exchange-broker/src/test/resources/features/exchange_test.feature
@@ -3,11 +3,13 @@ Feature: Jms Testing
     Scenario: Connection Test
         Given a "broker" client as "broker_client"
         And client "broker_client" is started
+        Then wait for 200 milliseconds
         Then send an "TestMessage" message with "Test=Value" using "broker_client" to exchange "exchange"
 
     Scenario: Queue consumer
         Given a "broker" client as "broker_client"
         And client "broker_client" is started
+        Then wait for 200 milliseconds
         Then send an "TestMessage" message with "Test=Value" using "broker_client" to exchange "exchange"
         Then wait for "broker_client" to receive a message on queue "exchange_queue" within 2 seconds
 
@@ -16,6 +18,7 @@ Feature: Jms Testing
         Given a "broker" client as "client_b"
         And client "client_a" is started
         And client "client_b" is started
+        Then wait for 200 milliseconds
         Then send a "TestMessage" message with "Test=Value" using "client_a" to exchange "exchange"
         Then wait for "client_b" to receive a message on queue "exchange_queue" within 2 seconds as "response"
         And check that "Test" in "response" is equal to "Value"

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/JmsTransport.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/JmsTransport.java
@@ -4,9 +4,11 @@ import com.neueda.etiqet.core.client.delegate.ClientDelegate;
 import com.neueda.etiqet.core.common.exceptions.EtiqetException;
 import com.neueda.etiqet.core.common.exceptions.EtiqetRuntimeException;
 import com.neueda.etiqet.core.message.cdr.Cdr;
+import com.neueda.etiqet.core.message.config.AbstractDictionary;
 import com.neueda.etiqet.core.transport.BrokerTransport;
 import com.neueda.etiqet.core.transport.Codec;
 import com.neueda.etiqet.core.transport.TransportDelegate;
+import com.neueda.etiqet.core.transport.delegate.BinaryMessageConverterDelegate;
 import com.neueda.etiqet.transport.jms.config.JmsConfigExtractor;
 import com.neueda.etiqet.transport.jms.config.JmsConfigXmlParser;
 import com.neueda.etiqet.transport.jms.config.model.ConstructorArgument;
@@ -20,6 +22,7 @@ import javax.jms.*;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -37,9 +40,10 @@ public class JmsTransport implements BrokerTransport {
     private Connection connection;
     private Session session;
     private Codec<Cdr, ?> codec;
+    private AbstractDictionary dictionary;
     private String defaultTopic;
     private ClientDelegate delegate;
-    private TransportDelegate<String, Cdr> transDel;
+    private BinaryMessageConverterDelegate binaryMessageConverterDelegate;
 
     /**
      * Instantiates a Jms connection factory and determines the default topic to publish messages to
@@ -51,6 +55,7 @@ public class JmsTransport implements BrokerTransport {
     public void init(String configPath) throws EtiqetException {
         JmsConfigExtractor jmsConfigExtractor = new JmsConfigExtractor(new JmsConfigXmlParser());
         JmsConfig configuration = jmsConfigExtractor.retrieveConfiguration(configPath);
+        binaryMessageConverterDelegate = instantiateBinaryMessageConverterDelegate(configuration);
         connectionFactory = createConnectionFactory(configuration);
         defaultTopic = configuration.getDefaultTopic();
     }
@@ -86,7 +91,20 @@ public class JmsTransport implements BrokerTransport {
         }
     }
 
-
+    private BinaryMessageConverterDelegate instantiateBinaryMessageConverterDelegate(JmsConfig config) throws EtiqetException {
+        Optional<Class> delegateClass = config.getBinaryMessageConverterDelegateClass();
+        if (delegateClass.isPresent()) {
+            try {
+                BinaryMessageConverterDelegate delegate = (BinaryMessageConverterDelegate) delegateClass.get().newInstance();
+                delegate.setDictionary(dictionary);
+                return delegate;
+            } catch (ReflectiveOperationException e) {
+                throw new EtiqetException("Unable to instantiate BinaryMessageConverterDelegate " + delegateClass.get().getName());
+            }
+        } else {
+            return null;
+        }
+    }
 
     /**
      * Starts a connection to the configured Jms bus
@@ -174,7 +192,6 @@ public class JmsTransport implements BrokerTransport {
      */
     @Override
     public void setTransportDelegate(TransportDelegate<String, Cdr> transDel) {
-        this.transDel = transDel;
     }
 
     /**
@@ -272,8 +289,12 @@ public class JmsTransport implements BrokerTransport {
         final Message message;
         if (payload instanceof String) {
             message = session.createTextMessage((String) payload);
-        } else {
+        } else if (binaryMessageConverterDelegate == null) {
             message = session.createObjectMessage((Serializable) payload);
+        } else {
+            BytesMessage bytesMessage = session.createBytesMessage();
+            bytesMessage.writeBytes(binaryMessageConverterDelegate.toByteArray(payload));
+            message = bytesMessage;
         }
         producer.send(message);
     }
@@ -330,8 +351,10 @@ public class JmsTransport implements BrokerTransport {
             TextMessage txt = (TextMessage) message;
             messageContent = txt.getText();
         } else if (message instanceof BytesMessage) {
-            BytesMessage bytesXMLMessage = ((BytesMessage) message);
-            messageContent = bytesXMLMessage.getBody(Message.class);
+            BytesMessage bytesXMLMessage = (BytesMessage) message;
+            byte[] binaryMessage = new byte[(int) bytesXMLMessage.getBodyLength()];
+            bytesXMLMessage.readBytes(binaryMessage);
+            messageContent = binaryMessageConverterDelegate.fromByteArray(binaryMessage);
         } else if (message instanceof ObjectMessage) {
             messageContent = ((ObjectMessage) message).getObject();
         } else {
@@ -376,4 +399,12 @@ public class JmsTransport implements BrokerTransport {
         this.defaultTopic = defaultTopic;
     }
 
+    @Override
+    public void setDictionary(AbstractDictionary dictionary) {
+        this.dictionary = dictionary;
+    }
+
+    public void setBinaryMessageConverterDelegate(BinaryMessageConverterDelegate binaryMessageConverterDelegate) {
+        this.binaryMessageConverterDelegate = binaryMessageConverterDelegate;
+    }
 }

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/config/JmsConfigExtractor.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/config/JmsConfigExtractor.java
@@ -31,15 +31,14 @@ public class JmsConfigExtractor {
         }
         return new JmsConfig(
             constructorClass,
-            getConstructorArguments(jmsConfiguration.getConstructorArgs()),
-            getSetterArguments(jmsConfiguration.getProperties()),
-            jmsConfiguration.getDefaultTopic()
+            constructorArguments(jmsConfiguration.getConstructorArgs()),
+            setterArguments(jmsConfiguration.getProperties()),
+            jmsConfiguration.getDefaultTopic(),
+            binaryMessageConverterDelegateClass(jmsConfiguration)
         );
     }
 
-
-
-    private List<ConstructorArgument> getConstructorArguments(final ConstructorArgs constructorArgs) {
+    private List<ConstructorArgument> constructorArguments(final ConstructorArgs constructorArgs) {
         if (constructorArgs == null) {
             return Collections.emptyList();
         }
@@ -68,7 +67,7 @@ public class JmsConfigExtractor {
     }
 
 
-    private List<SetterArgument> getSetterArguments(final Properties properties) {
+    private List<SetterArgument> setterArguments(final Properties properties) {
         if (properties == null) {
             return Collections.emptyList();
         }
@@ -85,4 +84,17 @@ public class JmsConfigExtractor {
             getArgumentValue(argumentType, prop.getArgValue())
         );
     }
+
+    private Class binaryMessageConverterDelegateClass(JmsConfiguration xmlConfiguration) throws EtiqetException{
+        try {
+            String binaryMessageConverterDelegateClassName = xmlConfiguration.getBinaryMessageConverterDelegate();
+            if (binaryMessageConverterDelegateClassName == null) {
+                return null;
+            }
+            return Class.forName(binaryMessageConverterDelegateClassName);
+        } catch (ReflectiveOperationException e) {
+            throw new EtiqetException("Unable to find BinaryMessageConverterDelegate class " + xmlConfiguration.getBinaryMessageConverterDelegate());
+        }
+    }
+
 }

--- a/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/config/model/JmsConfig.java
+++ b/etiqet-transport-jms/src/main/java/com/neueda/etiqet/transport/jms/config/model/JmsConfig.java
@@ -1,18 +1,21 @@
 package com.neueda.etiqet.transport.jms.config.model;
 
 import java.util.List;
+import java.util.Optional;
 
 public class JmsConfig {
     private Class implementation;
     private List<ConstructorArgument> constructorArgs;
     private List<SetterArgument> setterArgs;
     private String defaultTopic;
+    private Class binaryMessageConverterDelegate;
 
-    public JmsConfig(Class implementation, List<ConstructorArgument> constructorArgs, List<SetterArgument> setterArgs, String defaultTopic) {
+    public JmsConfig(Class implementation, List<ConstructorArgument> constructorArgs, List<SetterArgument> setterArgs, String defaultTopic, Class binaryMessageConverterDelegate) {
         this.implementation = implementation;
         this.constructorArgs = constructorArgs;
         this.setterArgs = setterArgs;
         this.defaultTopic = defaultTopic;
+        this.binaryMessageConverterDelegate = binaryMessageConverterDelegate;
     }
 
     public Class getImplementation() {
@@ -29,5 +32,9 @@ public class JmsConfig {
 
     public String getDefaultTopic() {
         return defaultTopic;
+    }
+
+    public Optional<Class> getBinaryMessageConverterDelegateClass() {
+        return Optional.ofNullable(binaryMessageConverterDelegate);
     }
 }

--- a/etiqet-transport-jms/src/main/resources/etiqet_jms.xsd
+++ b/etiqet-transport-jms/src/main/resources/etiqet_jms.xsd
@@ -11,6 +11,7 @@
             </xs:sequence>
             <xs:attribute name="implementation" type="xs:string" use="required"/>
             <xs:attribute name="defaultTopic" type="xs:string" use="required"/>
+            <xs:attribute name="binaryMessageConverterDelegate" type="xs:string"/>
         </xs:complexType>
     </xs:element>
 

--- a/etiqet-transport-jms/src/test/java/com/neueda/etiqet/transport/jms/JmsTransportProtobufIntegrationTest.java
+++ b/etiqet-transport-jms/src/test/java/com/neueda/etiqet/transport/jms/JmsTransportProtobufIntegrationTest.java
@@ -1,15 +1,19 @@
 package com.neueda.etiqet.transport.jms;
 
-import com.example.tutorial.AddressBookProtos;
 import com.neueda.etiqet.core.client.delegate.SinkClientDelegate;
 import com.neueda.etiqet.core.message.cdr.Cdr;
 import com.neueda.etiqet.core.message.cdr.CdrItem;
+import com.neueda.etiqet.core.message.config.AbstractDictionary;
 import com.neueda.etiqet.core.message.dictionary.ProtobufDictionary;
 import com.neueda.etiqet.core.transport.Codec;
 import com.neueda.etiqet.core.transport.ProtobufCodec;
+import com.neueda.etiqet.core.transport.delegate.BinaryMessageConverterDelegate;
+import com.neueda.etiqet.core.transport.delegate.ProtobufBinaryMessageConverterDelegate;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.junit.EmbeddedActiveMQBroker;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
 
 import java.util.Map;
 import java.util.Optional;
@@ -25,19 +29,6 @@ public class JmsTransportProtobufIntegrationTest {
     @Rule
     public EmbeddedActiveMQBroker broker;
 
-    @Before
-    public void setup() throws Exception {
-        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
-        connectionFactory.setTrustAllPackages(true);
-        jmsTransport = new JmsTransport();
-        Codec codec = new ProtobufCodec();
-        codec.setDictionary(new ProtobufDictionary("config/dictionary/addressbook.desc"));
-        jmsTransport.setCodec(codec);
-        jmsTransport.setConnectionFactory(connectionFactory);
-        jmsTransport.setDelegate(new SinkClientDelegate());
-        jmsTransport.start();
-    }
-
     @After
     public void tearDown() throws Exception {
         jmsTransport.stop();
@@ -45,6 +36,7 @@ public class JmsTransportProtobufIntegrationTest {
 
     @Test
     public void testSubscribeToTopicAndReceiveMessages() throws Exception {
+        initTransport(null);
         final String topicName = "topicTest01";
         BlockingQueue<Cdr> receivedMessages = new LinkedBlockingQueue<>();
         Cdr cdr = aCdr("Person")
@@ -63,6 +55,46 @@ public class JmsTransportProtobufIntegrationTest {
         assertEquals(34, Math.round(values.get("id").getIntval()));
         assertEquals("aaa@aaa.aaa", values.get("email").getStrval());
 
+    }
+
+    @Test
+    public void testSubscribeToTopicAndReceiveBinaryMessages() throws Exception {
+        initTransport(new ProtobufBinaryMessageConverterDelegate());
+        final String topicName = "topicTest01";
+        BlockingQueue<Cdr> receivedMessages = new LinkedBlockingQueue<>();
+        Cdr cdr = aCdr("Person")
+            .withField("name", "PersonName")
+            .withField("id", 34)
+            .withField("email", "aaa@aaa.aaa")
+            .build();
+
+        jmsTransport.subscribeToTopic(Optional.of(topicName), message -> receivedMessages.add(message));
+        jmsTransport.sendToTopic(cdr, Optional.of(topicName));
+        Thread.sleep(200);
+
+        assertEquals(1, receivedMessages.size());
+        Map<String, CdrItem> values = receivedMessages.take().getItems();
+        assertEquals("PersonName", values.get("name").getStrval());
+        assertEquals(34, Math.round(values.get("id").getIntval()));
+        assertEquals("aaa@aaa.aaa", values.get("email").getStrval());
+    }
+
+    private void initTransport(BinaryMessageConverterDelegate binaryMessageConverterDelegate) throws Exception {
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
+        connectionFactory.setTrustAllPackages(true);
+        AbstractDictionary dictionary = new ProtobufDictionary("config/dictionary/addressbook.desc");
+        jmsTransport = new JmsTransport();
+        jmsTransport.setDictionary(dictionary);
+        Codec codec = new ProtobufCodec();
+        codec.setDictionary(dictionary);
+        jmsTransport.setCodec(codec);
+        jmsTransport.setConnectionFactory(connectionFactory);
+        if (binaryMessageConverterDelegate != null) {
+            binaryMessageConverterDelegate.setDictionary(dictionary);
+        }
+        jmsTransport.setBinaryMessageConverterDelegate(binaryMessageConverterDelegate);
+        jmsTransport.setDelegate(new SinkClientDelegate());
+        jmsTransport.start();
     }
 
 }


### PR DESCRIPTION
Binary conversion delegate added to JMS transport. If present for the transport, the message will be converted as:
* cdr -> codec.encode(cdr) -> binaryconverterdelegate.tobytearray -> producer.send
* bytes[] message -> binaryconverterdelegate.frombytearray -> codec.decode -> cdr

If the delegate is missing, the payload object will be serialized by the client directly; only the codec will be involved in the process.